### PR TITLE
adiciona novo município

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ Todo o cálculo de feriados é feito no próprio frontend.
 
 ## Contribuindo
 
-Sinta-se livre para abrir pull requests e issues!
+Sinta-se livre para abrir pull requests e issues, por exemplo incluindo feriados municipais da sua cidade!

--- a/feriados_calculo.js
+++ b/feriados_calculo.js
@@ -425,6 +425,12 @@ function obterFeriadosMunicipais(ano, uf, municipio) {
             { tipo: "MUNICIPAL", data: new Date(ano, AGOSTO, 20), descricao: "Aniversário da cidade" },
             diaDaConscienciaNegra(),
         ];
+        case "SP/São Carlos": return [
+          { tipo: "MUNICIPAL", data: new Date(ano, AGOSTO, 15), descricao: "Nossa Senhora da Babilônia" },
+          { tipo: "MUNICIPAL", data: new Date(ano, OUTUBRO, 15), descricao: "Dia do Professor (somente para os professores da rede municipal de ensino)" },
+          { tipo: "MUNICIPAL", data: new Date(ano, NOVEMBRO, 4), descricao: "Aniversário de São Carlos" },
+          diaDeCorpusChristi(),
+        ];
         case "SP/São José dos Campos": return [
             { tipo: "MUNICIPAL", data: new Date(ano, MARCO, 13), descricao: "Dia de São José" },
             diaDeCorpusChristi(),
@@ -434,12 +440,6 @@ function obterFeriadosMunicipais(ano, uf, municipio) {
             { tipo: "MUNICIPAL", data: new Date(ano, JANEIRO, 25), descricao: "Aniversário de São Paulo" },
             diaDeCorpusChristi(),
             diaDaConscienciaNegra(),
-        ];
-        case "SP/São Carlos": return [
-            { tipo: "MUNICIPAL", data: new Date(ano, AGOSTO, 15), descricao: "Nossa Senhora da Babilônia" },
-            { tipo: "MUNICIPAL", data: new Date(ano, OUTUBRO, 15), descricao: "Dia do Professor (somente para os professores da rede municipal de ensino)" },
-            { tipo: "MUNICIPAL", data: new Date(ano, NOVEMBRO, 4), descricao: "Aniversário de São Carlos" },
-            diaDeCorpusChristi(),
         ];
         case "SE/Aracaju": return [
             { tipo: "MUNICIPAL", data: new Date(ano, MARCO, 17), descricao: "Aniversário de Aracaju" },

--- a/feriados_calculo.js
+++ b/feriados_calculo.js
@@ -436,9 +436,9 @@ function obterFeriadosMunicipais(ano, uf, municipio) {
             diaDaConscienciaNegra(),
         ];
         case "SP/São Carlos": return [
-            { tipo: "MUNICIPAL", data: new Date(ano, AGOSTO, 15), descricao: "Nossa Senhora da Babilônia (feriado municipal)" },
-            { tipo: "MUNICIPAL", data: new Date(ano, OUTUBRO, 15), descricao: "Dia do Professor (feriado municipal, somente para os professores da rede municipal de ensino)" },
-            { tipo: "MUNICIPAL", data: new Date(ano, NOVEMBRO, 4), descricao: "Aniversário de São Carlos (feriado municipal)" },
+            { tipo: "MUNICIPAL", data: new Date(ano, AGOSTO, 15), descricao: "Nossa Senhora da Babilônia" },
+            { tipo: "MUNICIPAL", data: new Date(ano, OUTUBRO, 15), descricao: "Dia do Professor (somente para os professores da rede municipal de ensino)" },
+            { tipo: "MUNICIPAL", data: new Date(ano, NOVEMBRO, 4), descricao: "Aniversário de São Carlos" },
             diaDeCorpusChristi(),
         ];
         case "SE/Aracaju": return [

--- a/feriados_calculo.js
+++ b/feriados_calculo.js
@@ -25,7 +25,7 @@ const estados = [
     { acronimo: "RO", nome: "Rondônia", cidades: ["Porto Velho"] },
     { acronimo: "RR", nome: "Roraima", cidades: ["Boa Vista"] },
     { acronimo: "SC", nome: "Santa Catarina", cidades: ["Balneário Camboriú", "Blumenau", "Florianópolis", "Joinville"] },
-    { acronimo: "SP", nome: "São Paulo", cidades: ["Barueri", "Campinas", "Guarulhos", "Osasco", "Ribeirão Preto", "Santo André", "São Bernardo do Campo", "São José dos Campos", "São Paulo"] },
+    { acronimo: "SP", nome: "São Paulo", cidades: ["Barueri", "Campinas", "Guarulhos", "Osasco", "Ribeirão Preto", "Santo André", "São Bernardo do Campo", "São José dos Campos", "São Paulo", "São Carlos"] },
     { acronimo: "SE", nome: "Sergipe", cidades: ["Aracaju"] },
     { acronimo: "TO", nome: "Tocantins", cidades: ["Palmas"] }
 ];
@@ -434,6 +434,24 @@ function obterFeriadosMunicipais(ano, uf, municipio) {
             { tipo: "MUNICIPAL", data: new Date(ano, JANEIRO, 25), descricao: "Aniversário de São Paulo" },
             diaDeCorpusChristi(),
             diaDaConscienciaNegra(),
+        ];
+        case "SP/São Carlos": return [
+            { tipo: "MUNICIPAL", data: new Date(ano, JANEIRO, 2), descricao: "(ponto facultativo)" },
+            { tipo: "MUNICIPAL", data: new Date(ano, FEVEREIRO, 20), descricao: "Carnaval (ponto facultativo)" },
+            { tipo: "MUNICIPAL", data: new Date(ano, FEVEREIRO, 21), descricao: "Carnaval (ponto facultativo)" },
+            { tipo: "MUNICIPAL", data: new Date(ano, FEVEREIRO, 22), descricao: "Cinzas (ponto facultativo até as 12 horas)" },
+            { tipo: "MUNICIPAL", data: new Date(ano, ABRIL, 7), descricao: "Paixão de Cristo (feriado municipal)" },
+            { tipo: "MUNICIPAL", data: new Date(ano, JUNHO, 9), descricao: "(ponto facultativo)" },
+            { tipo: "MUNICIPAL", data: new Date(ano, AGOSTO, 14), descricao: "(ponto facultativo)" },
+            { tipo: "MUNICIPAL", data: new Date(ano, AGOSTO, 15), descricao: "Nossa Senhora da Babilônia (feriado municipal)" },
+            { tipo: "MUNICIPAL", data: new Date(ano, SETEMBRO, 8), descricao: "(ponto facultativo)" },
+            { tipo: "MUNICIPAL", data: new Date(ano, OUTUBRO, 13), descricao: "(ponto facultativo)" },
+            { tipo: "MUNICIPAL", data: new Date(ano, OUTUBRO, 15), descricao: "Dia do Professor (feriado municipal, somente para os professores da rede municipal de ensino)" },
+            { tipo: "MUNICIPAL", data: new Date(ano, OUTUBRO, 28), descricao: "Dia do Funcionário Público (ponto facultativo)" },
+            { tipo: "MUNICIPAL", data: new Date(ano, NOVEMBRO, 3), descricao: "(ponto facultativo)" },
+            { tipo: "MUNICIPAL", data: new Date(ano, NOVEMBRO, 4), descricao: "Aniversário de São Carlos (feriado municipal)" },
+            { tipo: "MUNICIPAL", data: new Date(ano, DEZEMBRO, 26), descricao: "(ponto facultativo)" },
+            diaDeCorpusChristi(),
         ];
         case "SE/Aracaju": return [
             { tipo: "MUNICIPAL", data: new Date(ano, MARCO, 17), descricao: "Aniversário de Aracaju" },

--- a/feriados_calculo.js
+++ b/feriados_calculo.js
@@ -25,7 +25,7 @@ const estados = [
     { acronimo: "RO", nome: "Rondônia", cidades: ["Porto Velho"] },
     { acronimo: "RR", nome: "Roraima", cidades: ["Boa Vista"] },
     { acronimo: "SC", nome: "Santa Catarina", cidades: ["Balneário Camboriú", "Blumenau", "Florianópolis", "Joinville"] },
-    { acronimo: "SP", nome: "São Paulo", cidades: ["Barueri", "Campinas", "Guarulhos", "Osasco", "Ribeirão Preto", "Santo André", "São Bernardo do Campo", "São José dos Campos", "São Paulo", "São Carlos"] },
+    { acronimo: "SP", nome: "São Paulo", cidades: ["Barueri", "Campinas", "Guarulhos", "Osasco", "Ribeirão Preto", "Santo André", "São Bernardo do Campo", "São Carlos", "São José dos Campos", "São Paulo"] },
     { acronimo: "SE", nome: "Sergipe", cidades: ["Aracaju"] },
     { acronimo: "TO", nome: "Tocantins", cidades: ["Palmas"] }
 ];

--- a/feriados_calculo.js
+++ b/feriados_calculo.js
@@ -436,21 +436,9 @@ function obterFeriadosMunicipais(ano, uf, municipio) {
             diaDaConscienciaNegra(),
         ];
         case "SP/São Carlos": return [
-            { tipo: "MUNICIPAL", data: new Date(ano, JANEIRO, 2), descricao: "(ponto facultativo)" },
-            { tipo: "MUNICIPAL", data: new Date(ano, FEVEREIRO, 20), descricao: "Carnaval (ponto facultativo)" },
-            { tipo: "MUNICIPAL", data: new Date(ano, FEVEREIRO, 21), descricao: "Carnaval (ponto facultativo)" },
-            { tipo: "MUNICIPAL", data: new Date(ano, FEVEREIRO, 22), descricao: "Cinzas (ponto facultativo até as 12 horas)" },
-            { tipo: "MUNICIPAL", data: new Date(ano, ABRIL, 7), descricao: "Paixão de Cristo (feriado municipal)" },
-            { tipo: "MUNICIPAL", data: new Date(ano, JUNHO, 9), descricao: "(ponto facultativo)" },
-            { tipo: "MUNICIPAL", data: new Date(ano, AGOSTO, 14), descricao: "(ponto facultativo)" },
             { tipo: "MUNICIPAL", data: new Date(ano, AGOSTO, 15), descricao: "Nossa Senhora da Babilônia (feriado municipal)" },
-            { tipo: "MUNICIPAL", data: new Date(ano, SETEMBRO, 8), descricao: "(ponto facultativo)" },
-            { tipo: "MUNICIPAL", data: new Date(ano, OUTUBRO, 13), descricao: "(ponto facultativo)" },
             { tipo: "MUNICIPAL", data: new Date(ano, OUTUBRO, 15), descricao: "Dia do Professor (feriado municipal, somente para os professores da rede municipal de ensino)" },
-            { tipo: "MUNICIPAL", data: new Date(ano, OUTUBRO, 28), descricao: "Dia do Funcionário Público (ponto facultativo)" },
-            { tipo: "MUNICIPAL", data: new Date(ano, NOVEMBRO, 3), descricao: "(ponto facultativo)" },
             { tipo: "MUNICIPAL", data: new Date(ano, NOVEMBRO, 4), descricao: "Aniversário de São Carlos (feriado municipal)" },
-            { tipo: "MUNICIPAL", data: new Date(ano, DEZEMBRO, 26), descricao: "(ponto facultativo)" },
             diaDeCorpusChristi(),
         ];
         case "SE/Aracaju": return [


### PR DESCRIPTION
- adiciona feriados para São Carlos, SP
- FIX: Exibir cidade em ordem alfabética no SELECT.
- Não devemos incluir pontos facultativos.
- Descrição não deve indicar o tipo "feriado municipal".
- atualiza readme pra tentar sincronizar o pr
- Definições dos municípios devem estar em ordem alfabética.
